### PR TITLE
Added forced hash picking

### DIFF
--- a/src/main/java/net/elytrium/limboauth/Settings.java
+++ b/src/main/java/net/elytrium/limboauth/Settings.java
@@ -85,6 +85,14 @@ public class Settings extends Config {
         "Argon2 - Argon2 hash that looks like $argon2i$v=1234$m=1234,t=1234,p=1234$hash",
     })
     public String MIGRATION_HASH = "";
+    @Comment({
+        "This option can be used if you have a variety of hashes in your config",
+        "Although it is not recommended, as it's time consuming and may cause",
+        "a false validation.",
+        "The way this works is it picks through all algorithms, trying to validate",
+        "a stored hash. If none return a positive result, the password is wrong."
+    })
+    public boolean FORCED_HASH_PICKING = false;
     @Comment("Available dimensions: OVERWORLD, NETHER, THE_END")
     public String DIMENSION = "THE_END";
     public long PURGE_CACHE_MILLIS = 3600000;

--- a/src/main/java/net/elytrium/limboauth/Settings.java
+++ b/src/main/java/net/elytrium/limboauth/Settings.java
@@ -83,6 +83,7 @@ public class Settings extends Config {
         "SHA512_DBA - DBA plugin SHA512(SHA512(password) + salt) that looks like SHA$salt$hash",
         "MD5 - Basic md5 hash",
         "ARGON2 - Argon2 hash that looks like $argon2i$v=1234$m=1234,t=1234,p=1234$hash",
+        "MOON_SHA256 - Moon SHA256(SHA256(password)) that looks like $SHA$hash (no salt)"
     })
     public String MIGRATION_HASH = "";
     @Comment({

--- a/src/main/java/net/elytrium/limboauth/Settings.java
+++ b/src/main/java/net/elytrium/limboauth/Settings.java
@@ -93,6 +93,12 @@ public class Settings extends Config {
         "a stored hash. If none return a positive result, the password is wrong."
     })
     public boolean FORCED_HASH_PICKING = false;
+    @Comment({
+        "This option is IGNORED when FORCED_HASH_PICKING=false",
+        "In case some hashing algorithms are never used",
+        "or throw errors when picked, you can disable them here."
+    })
+    public List<String> FORCED_HASH_EXCLUSIONS = List.of("Argon2", "MD5");
     @Comment("Available dimensions: OVERWORLD, NETHER, THE_END")
     public String DIMENSION = "THE_END";
     public long PURGE_CACHE_MILLIS = 3600000;

--- a/src/main/java/net/elytrium/limboauth/Settings.java
+++ b/src/main/java/net/elytrium/limboauth/Settings.java
@@ -83,7 +83,7 @@ public class Settings extends Config {
         "SHA512_DBA - DBA plugin SHA512(SHA512(password) + salt) that looks like SHA$salt$hash",
         "MD5 - Basic md5 hash",
         "ARGON2 - Argon2 hash that looks like $argon2i$v=1234$m=1234,t=1234,p=1234$hash",
-        "MOON_SHA256 - Moon SHA256(SHA256(password)) that looks like $SHA$hash (no salt)"
+        "MOON_SHA256 - Moon SHA256(SHA256(password)) that looks like $SHA$hash (no salt)",
     })
     public String MIGRATION_HASH = "";
     @Comment({

--- a/src/main/java/net/elytrium/limboauth/Settings.java
+++ b/src/main/java/net/elytrium/limboauth/Settings.java
@@ -82,7 +82,7 @@ public class Settings extends Config {
         "SHA512_P - SHA512(password) that looks like $SHA$salt$hash",
         "SHA512_DBA - DBA plugin SHA512(SHA512(password) + salt) that looks like SHA$salt$hash",
         "MD5 - Basic md5 hash",
-        "Argon2 - Argon2 hash that looks like $argon2i$v=1234$m=1234,t=1234,p=1234$hash",
+        "ARGON2 - Argon2 hash that looks like $argon2i$v=1234$m=1234,t=1234,p=1234$hash",
     })
     public String MIGRATION_HASH = "";
     @Comment({
@@ -98,7 +98,7 @@ public class Settings extends Config {
         "In case some hashing algorithms are never used",
         "or throw errors when picked, you can disable them here."
     })
-    public List<String> FORCED_HASH_EXCLUSIONS = List.of("Argon2", "MD5");
+    public List<String> FORCED_HASH_EXCLUSIONS = List.of("ARGON2", "MD5");
     @Comment("Available dimensions: OVERWORLD, NETHER, THE_END")
     public String DIMENSION = "THE_END";
     public long PURGE_CACHE_MILLIS = 3600000;

--- a/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
+++ b/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
@@ -222,6 +222,7 @@ public class AuthSessionHandler implements LimboSessionHandler {
     if (!isCorrect) {
       if (Settings.IMP.MAIN.FORCED_HASH_PICKING) {
         isCorrect = Arrays.stream(MigrationHash.values())
+            .filter(migrationHash -> !Settings.IMP.MAIN.FORCED_HASH_EXCLUSIONS.contains(migrationHash.toString()))
             .anyMatch(migrationHash -> migrationHash.checkPassword(player.getHash(), password));
       } else if (!Settings.IMP.MAIN.MIGRATION_HASH.isEmpty()) {
         isCorrect = MigrationHash.valueOf(Settings.IMP.MAIN.MIGRATION_HASH).checkPassword(player.getHash(), password);

--- a/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
+++ b/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
@@ -28,6 +28,7 @@ import dev.samstevens.totp.time.SystemTimeProvider;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -218,8 +219,13 @@ public class AuthSessionHandler implements LimboSessionHandler {
         player.getHash().replace("BCRYPT$", "$2a$").getBytes(StandardCharsets.UTF_8)
     ).verified;
 
-    if (!isCorrect && !Settings.IMP.MAIN.MIGRATION_HASH.isEmpty()) {
-      isCorrect = MigrationHash.valueOf(Settings.IMP.MAIN.MIGRATION_HASH).checkPassword(player.getHash(), password);
+    if (!isCorrect) {
+      if (Settings.IMP.MAIN.FORCED_HASH_PICKING) {
+        isCorrect = Arrays.stream(MigrationHash.values())
+            .anyMatch(migrationHash -> migrationHash.checkPassword(player.getHash(), password));
+      } else if (!Settings.IMP.MAIN.MIGRATION_HASH.isEmpty()) {
+        isCorrect = MigrationHash.valueOf(Settings.IMP.MAIN.MIGRATION_HASH).checkPassword(player.getHash(), password);
+      }
 
       if (isCorrect) {
         player.setHash(genHash(password));


### PR DESCRIPTION
In my use case I faced a problem of having hashed formed by multiple different algorithms and specifying one MIGRATION_HASH was not enough.

Offered solution is a config option allowing a user to forcibly enable hash picking, where every a stored value will be compared with the password hashed using every possible algorithm.