### PR TITLE
Keep hash after enabling premium

### DIFF
--- a/src/main/java/net/elytrium/limboauth/LimboAuth.java
+++ b/src/main/java/net/elytrium/limboauth/LimboAuth.java
@@ -491,9 +491,9 @@ public class LimboAuth {
       TaskEvent.Result result = TaskEvent.Result.NORMAL;
 
       if (onlineMode || isFloodgate) {
-        if (registeredPlayer == null || registeredPlayer.getHash().isEmpty()) {
+        if (registeredPlayer == null || registeredPlayer.getPremium()) {
           registeredPlayer = AuthSessionHandler.fetchInfo(this.playerDao, player.getUniqueId());
-          if (registeredPlayer == null || registeredPlayer.getHash().isEmpty()) {
+          if (registeredPlayer == null || registeredPlayer.getPremium()) {
             // Due to the current connection state, which is set to LOGIN there, we cannot send the packets.
             // We need to wait for the PLAY connection state to set.
             this.postLoginTasks.put(player.getUniqueId(), () -> {
@@ -605,14 +605,14 @@ public class LimboAuth {
           premiumRegisteredQuery.where()
               .eq("LOWERCASENICKNAME", nickname.toLowerCase(Locale.ROOT))
               .and()
-              .ne("HASH", "");
+              .ne("PREMIUM", 1);
           premiumRegisteredQuery.setCountOf(true);
 
           QueryBuilder<RegisteredPlayer, String> premiumUnregisteredQuery = this.playerDao.queryBuilder();
           premiumUnregisteredQuery.where()
               .eq("LOWERCASENICKNAME", nickname.toLowerCase(Locale.ROOT))
               .and()
-              .eq("HASH", "");
+              .ne("PREMIUM", 0);
           premiumUnregisteredQuery.setCountOf(true);
 
           if (Settings.IMP.MAIN.ONLINE_MODE_NEED_AUTH) {

--- a/src/main/java/net/elytrium/limboauth/command/PremiumCommand.java
+++ b/src/main/java/net/elytrium/limboauth/command/PremiumCommand.java
@@ -74,12 +74,12 @@ public class PremiumCommand implements SimpleCommand {
           RegisteredPlayer player = AuthSessionHandler.fetchInfo(this.playerDao, username);
           if (player == null) {
             source.sendMessage(this.notRegistered, MessageType.SYSTEM);
-          } else if (player.getHash().isEmpty()) {
+          } else if (player.getPremium()) {
             source.sendMessage(this.alreadyPremium, MessageType.SYSTEM);
           } else if (AuthSessionHandler.checkPassword(args[0], player, this.playerDao)) {
             if (this.plugin.isPremiumExternal(username)) {
               try {
-                player.setHash("");
+                player.setPremium(true);
                 this.playerDao.update(player);
                 this.plugin.removePlayerFromCache(username);
                 ((Player) source).disconnect(this.successful);

--- a/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
+++ b/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
@@ -193,6 +193,7 @@ public class AuthSessionHandler implements LimboSessionHandler {
               username,
               username.toLowerCase(Locale.ROOT),
               genHash(args[1]),
+              false,
               this.ip,
               "",
               System.currentTimeMillis(),

--- a/src/main/java/net/elytrium/limboauth/listener/AuthListener.java
+++ b/src/main/java/net/elytrium/limboauth/listener/AuthListener.java
@@ -94,7 +94,7 @@ public class AuthListener {
       if (registeredPlayer != null) {
         String currentUuid = registeredPlayer.getUuid();
 
-        if (event.isOnlineMode() && registeredPlayer.getHash().isEmpty() && registeredPlayer.getPremiumUuid().isEmpty()) {
+        if (event.isOnlineMode() && registeredPlayer.getPremium() && registeredPlayer.getPremiumUuid().isEmpty()) {
           try {
             registeredPlayer.setPremiumUuid(event.getOriginalProfile().getId().toString());
             this.playerDao.update(registeredPlayer);

--- a/src/main/java/net/elytrium/limboauth/model/RegisteredPlayer.java
+++ b/src/main/java/net/elytrium/limboauth/model/RegisteredPlayer.java
@@ -32,6 +32,9 @@ public class RegisteredPlayer {
   @DatabaseField(canBeNull = false, columnName = "HASH")
   private String hash;
 
+  @DatabaseField(canBeNull = false, columnName = "PREMIUM")
+  private boolean premium;
+
   @DatabaseField(columnName = "IP")
   private String ip;
 
@@ -48,10 +51,11 @@ public class RegisteredPlayer {
   private String premiumUuid;
 
   public RegisteredPlayer(String nickname, String lowercaseNickname,
-      String hash, String ip, String totpToken, Long regDate, String uuid, String premiumUuid) {
+      String hash, boolean premium, String ip, String totpToken, Long regDate, String uuid, String premiumUuid) {
     this.nickname = nickname;
     this.lowercaseNickname = lowercaseNickname;
     this.hash = hash;
+    this.premium = premium;
     this.ip = ip;
     this.totpToken = totpToken;
     this.regDate = regDate;
@@ -85,6 +89,14 @@ public class RegisteredPlayer {
 
   public String getHash() {
     return this.hash == null ? "" : this.hash;
+  }
+
+  public void setPremium(boolean premium) {
+    this.premium = premium;
+  }
+
+  public boolean getPremium() {
+    return this.premium;
   }
 
   public void setIP(String ip) {


### PR DESCRIPTION
I added a column PREMIUM, so hashes are stored after running /premium.

Unfortunately, I'm not entirely sure how the "online-mode-need-auth" option works, but it seemingly behaves the same way as in 1.0.6-SNAPSHOT.