### PR TITLE
Change Password Fixes

### DIFF
--- a/src/main/java/net/elytrium/limboauth/Settings.java
+++ b/src/main/java/net/elytrium/limboauth/Settings.java
@@ -74,6 +74,8 @@ public class Settings extends YamlConfig {
     public int MAX_PASSWORD_LENGTH = 71;
     public boolean CHECK_PASSWORD_STRENGTH = true;
     public String UNSAFE_PASSWORDS_FILE = "unsafe_passwords.txt";
+    @Comment("Determines whether or not /forcechangepassword command will bypass password length & strength checks.")
+    public boolean FORCE_CHANGE_PASSWORD_BYPASS_CHECK = true;
     @Comment({
         "Players with premium nicknames should register/auth if this option is enabled",
         "Players with premium nicknames must login with a premium Minecraft account if this option is disabled",
@@ -228,6 +230,9 @@ public class Settings extends YamlConfig {
         "True - as premium; False - as cracked"
     })
     public boolean ON_SERVER_ERROR_PREMIUM = true;
+
+    @Comment("Defines rate limit between command executions from same IP-address in milliseconds.")
+    public long COMMAND_RATE_LIMIT = 5000;
 
     public List<String> REGISTER_COMMAND = List.of("/r", "/reg", "/register");
     public List<String> LOGIN_COMMAND = List.of("/l", "/log", "/login");
@@ -464,8 +469,9 @@ public class Settings extends YamlConfig {
       public String REGISTRATIONS_DISABLED_KICK = "{PRFX} Registrations are currently disabled.";
 
       public String CHANGE_PASSWORD_SUCCESSFUL = "{PRFX} &aSuccessfully changed password!";
-      @Comment("Or if change-password-need-old-pass set to false remove the \"<old password>\" part.")
       public String CHANGE_PASSWORD_USAGE = "{PRFX} Usage: &6/changepassword <old password> <new password>";
+      @Comment("Used if change-password-need-old-pass set to false or the player, which is trying to change the password is premium.")
+      public String CHANGE_PASSWORD_NO_OLD_PASS_USAGE = "{PRFX} Usage: &6/changepassword <new password>";
 
       public String FORCE_CHANGE_PASSWORD_SUCCESSFUL = "{PRFX} &aSuccessfully changed password for player &6{0}&a!";
       public String FORCE_CHANGE_PASSWORD_MESSAGE = "{PRFX} &aYour password has been changed to &6{0} &aby an administator!";
@@ -527,9 +533,19 @@ public class Settings extends YamlConfig {
     private final Random random;
     private String originalValue;
 
-    public MD5KeySerializer() throws NoSuchAlgorithmException {
+    public MD5KeySerializer() {
       super(byte[].class, String.class);
-      this.md5 = MessageDigest.getInstance("MD5");
+
+      // Had to do this as spotbug was mad on me for throwing possible exception in class constructor
+      MessageDigest md5;
+      try {
+        md5 = MessageDigest.getInstance("MD5");
+      } catch (NoSuchAlgorithmException e) {
+        e.printStackTrace();
+        md5 = null;
+      }
+
+      this.md5 = md5;
       this.random = new SecureRandom();
     }
 

--- a/src/main/java/net/elytrium/limboauth/command/ChangePasswordCommand.java
+++ b/src/main/java/net/elytrium/limboauth/command/ChangePasswordCommand.java
@@ -24,11 +24,13 @@ import com.velocitypowered.api.command.SimpleCommand;
 import com.velocitypowered.api.proxy.Player;
 import java.sql.SQLException;
 import java.util.Locale;
+import javax.annotation.Nullable;
 import net.elytrium.commons.kyori.serialization.Serializer;
 import net.elytrium.limboauth.LimboAuth;
 import net.elytrium.limboauth.Settings;
 import net.elytrium.limboauth.event.ChangePasswordEvent;
 import net.elytrium.limboauth.handler.AuthSessionHandler;
+import net.elytrium.limboauth.helper.PasswordVerifier;
 import net.elytrium.limboauth.model.RegisteredPlayer;
 import net.elytrium.limboauth.model.SQLRuntimeException;
 import net.kyori.adventure.text.Component;
@@ -41,9 +43,13 @@ public class ChangePasswordCommand extends RatelimitedCommand {
   private final boolean needOldPass;
   private final Component notRegistered;
   private final Component wrongPassword;
+  private final Component passwordTooLong;
+  private final Component passwordTooShort;
+  private final Component passwordUnsafe;
   private final Component successful;
   private final Component errorOccurred;
   private final Component usage;
+  private final Component usageNoOldPass;
   private final Component notPlayer;
 
   public ChangePasswordCommand(LimboAuth plugin, Dao<RegisteredPlayer, String> playerDao) {
@@ -54,9 +60,14 @@ public class ChangePasswordCommand extends RatelimitedCommand {
     this.needOldPass = Settings.IMP.MAIN.CHANGE_PASSWORD_NEED_OLD_PASSWORD;
     this.notRegistered = serializer.deserialize(Settings.IMP.MAIN.STRINGS.NOT_REGISTERED);
     this.wrongPassword = serializer.deserialize(Settings.IMP.MAIN.STRINGS.WRONG_PASSWORD);
+    // At this point, I've decided to keep invalid password messages with REGISTER_ prefix for backwards compatibility.
+    this.passwordTooLong = serializer.deserialize(Settings.IMP.MAIN.STRINGS.REGISTER_PASSWORD_TOO_LONG);
+    this.passwordTooShort = serializer.deserialize(Settings.IMP.MAIN.STRINGS.REGISTER_PASSWORD_TOO_SHORT);
+    this.passwordUnsafe = serializer.deserialize(Settings.IMP.MAIN.STRINGS.REGISTER_PASSWORD_UNSAFE);
     this.successful = serializer.deserialize(Settings.IMP.MAIN.STRINGS.CHANGE_PASSWORD_SUCCESSFUL);
     this.errorOccurred = serializer.deserialize(Settings.IMP.MAIN.STRINGS.ERROR_OCCURRED);
     this.usage = serializer.deserialize(Settings.IMP.MAIN.STRINGS.CHANGE_PASSWORD_USAGE);
+    this.usageNoOldPass = serializer.deserialize(Settings.IMP.MAIN.STRINGS.CHANGE_PASSWORD_NO_OLD_PASS_USAGE);
     this.notPlayer = serializer.deserialize(Settings.IMP.MAIN.STRINGS.NOT_PLAYER);
   }
 
@@ -84,29 +95,19 @@ public class ChangePasswordCommand extends RatelimitedCommand {
           return;
         }
       } else if (args.length < 1) {
-        source.sendMessage(this.usage);
+        source.sendMessage(this.usageNoOldPass);
         return;
       }
 
-      try {
-        final String oldHash = player.getHash();
-        final String newPassword = needOldPass ? args[1] : args[0];
-        final String newHash = RegisteredPlayer.genHash(newPassword);
+      final PasswordVerifier passwordVerifier = new PasswordVerifier(this.plugin);
+      final String newPassword = needOldPass ? args[1] : args[0];
 
-        UpdateBuilder<RegisteredPlayer, String> updateBuilder = this.playerDao.updateBuilder();
-        updateBuilder.where().eq(RegisteredPlayer.LOWERCASE_NICKNAME_FIELD, usernameLowercase);
-        updateBuilder.updateColumnValue(RegisteredPlayer.HASH_FIELD, newHash);
-        updateBuilder.update();
+      switch (passwordVerifier.checkPassword(newPassword)) {
+        case PASSWORD_TOO_LONG -> source.sendMessage(this.passwordTooLong);
+        case PASSWORD_TOO_SHORT -> source.sendMessage(this.passwordTooShort);
+        case PASSWORD_UNSAFE -> source.sendMessage(this.passwordUnsafe);
 
-        this.plugin.removePlayerFromCacheLowercased(usernameLowercase);
-
-        this.plugin.getServer().getEventManager().fireAndForget(
-            new ChangePasswordEvent(player, needOldPass ? args[0] : null, oldHash, newPassword, newHash));
-
-        source.sendMessage(this.successful);
-      } catch (SQLException e) {
-        source.sendMessage(this.errorOccurred);
-        throw new SQLRuntimeException(e);
+        default -> this.performPasswordChange(source, player, usernameLowercase, needOldPass ? args[0] : null, newPassword);
       }
     } else {
       source.sendMessage(this.notPlayer);
@@ -117,5 +118,33 @@ public class ChangePasswordCommand extends RatelimitedCommand {
   public boolean hasPermission(SimpleCommand.Invocation invocation) {
     return Settings.IMP.MAIN.COMMAND_PERMISSION_STATE.CHANGE_PASSWORD
         .hasPermission(invocation.source(), "limboauth.commands.changepassword");
+  }
+
+  private void performPasswordChange(
+      CommandSource source,
+      RegisteredPlayer player,
+      String usernameLowercase,
+      @Nullable String oldPassword,
+      String newPassword
+  ) {
+    try {
+      final String oldHash = player.getHash();
+      final String newHash = RegisteredPlayer.genHash(newPassword);
+
+      UpdateBuilder<RegisteredPlayer, String> updateBuilder = this.playerDao.updateBuilder();
+      updateBuilder.where().eq(RegisteredPlayer.LOWERCASE_NICKNAME_FIELD, usernameLowercase);
+      updateBuilder.updateColumnValue(RegisteredPlayer.HASH_FIELD, newHash);
+      updateBuilder.update();
+
+      this.plugin.removePlayerFromCacheLowercased(usernameLowercase);
+
+      this.plugin.getServer().getEventManager().fireAndForget(
+          new ChangePasswordEvent(player, oldPassword, oldHash, newPassword, newHash));
+
+      source.sendMessage(this.successful);
+    } catch (SQLException e) {
+      source.sendMessage(this.errorOccurred);
+      throw new SQLRuntimeException(e);
+    }
   }
 }

--- a/src/main/java/net/elytrium/limboauth/command/RatelimitedCommand.java
+++ b/src/main/java/net/elytrium/limboauth/command/RatelimitedCommand.java
@@ -36,7 +36,7 @@ public abstract class RatelimitedCommand implements SimpleCommand {
   public final void execute(SimpleCommand.Invocation invocation) {
     CommandSource source = invocation.source();
     if (source instanceof Player) {
-      if (!LimboAuth.RATELIMITER.attempt(((Player) source).getRemoteAddress().getAddress())) {
+      if (!LimboAuth.getRatelimiter().attempt(((Player) source).getRemoteAddress().getAddress())) {
         source.sendMessage(this.ratelimited);
         return;
       }

--- a/src/main/java/net/elytrium/limboauth/helper/PasswordVerifier.java
+++ b/src/main/java/net/elytrium/limboauth/helper/PasswordVerifier.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2021 - 2024 Elytrium
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.elytrium.limboauth.helper;
+
+import net.elytrium.limboauth.LimboAuth;
+import net.elytrium.limboauth.Settings;
+
+public class PasswordVerifier {
+  private final LimboAuth plugin;
+
+  public PasswordVerifier(LimboAuth plugin) {
+    this.plugin = plugin;
+  }
+
+  public PasswordVerificationResult checkPassword(String[] args) {
+    if (this.checkPasswordsRepeat(args) != PasswordVerificationResult.PASSWORD_OK) {
+      return this.checkPasswordsRepeat(args);
+    }
+
+    return this.checkPassword(args[1]);
+  }
+
+  public PasswordVerificationResult checkPassword(String password) {
+    if (this.checkPasswordLength(password) != PasswordVerificationResult.PASSWORD_OK) {
+      return this.checkPasswordLength(password);
+    }
+
+    if (this.checkPasswordStrength(password) != PasswordVerificationResult.PASSWORD_OK) {
+      return this.checkPasswordStrength(password);
+    }
+
+    return PasswordVerificationResult.PASSWORD_OK;
+  }
+
+  public PasswordVerificationResult checkPasswordsRepeat(String[] args) {
+    if (!Settings.IMP.MAIN.REGISTER_NEED_REPEAT_PASSWORD || args[1].equals(args[2])) {
+      return PasswordVerificationResult.PASSWORD_OK;
+    } else {
+      return PasswordVerificationResult.PASSWORDS_DOESNT_MATCH;
+    }
+  }
+
+  public PasswordVerificationResult checkPasswordLength(String password) {
+    int length = password.length();
+    if (length > Settings.IMP.MAIN.MAX_PASSWORD_LENGTH) {
+      return PasswordVerificationResult.PASSWORD_TOO_LONG;
+    } else if (length < Settings.IMP.MAIN.MIN_PASSWORD_LENGTH) {
+      return PasswordVerificationResult.PASSWORD_TOO_SHORT;
+    } else {
+      return PasswordVerificationResult.PASSWORD_OK;
+    }
+  }
+
+  public PasswordVerificationResult checkPasswordStrength(String password) {
+    if (Settings.IMP.MAIN.CHECK_PASSWORD_STRENGTH && this.plugin.getUnsafePasswords().contains(password)) {
+      return PasswordVerificationResult.PASSWORD_UNSAFE;
+    } else {
+      return PasswordVerificationResult.PASSWORD_OK;
+    }
+  }
+
+  public enum PasswordVerificationResult {
+    PASSWORDS_DOESNT_MATCH,
+    PASSWORD_TOO_LONG,
+    PASSWORD_TOO_SHORT,
+    PASSWORD_UNSAFE,
+    PASSWORD_OK
+  }
+}


### PR DESCRIPTION
This PR addresses change password command not validating user password and minor enhancements.

### Added:

- Ability to change commands ratelimit in config.
- Separate changepass usage message for premium users and if old password is disabled.

### Fixed:

- A bug, where /changepass and /forcechangepassword (optional) won't verify the password.
- Some minor spotbug nitpicks

I really hope that this plugin will thrive, because this is a quite good authorization plugin.
