### PR TITLE
Build against LimboAPI 1.1.27 for Minecraft 26.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ setGroup("net.elytrium")
 setVersion("1.1.14")
 
 java {
-    setSourceCompatibility(JavaVersion.VERSION_17)
-    setTargetCompatibility(JavaVersion.VERSION_17)
+    setSourceCompatibility(JavaVersion.VERSION_21)
+    setTargetCompatibility(JavaVersion.VERSION_21)
 }
 
 compileJava {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-limboapiVersion=1.1.26
-velocityVersion=3.4.0-SNAPSHOT
+limboapiVersion=1.1.27
+velocityVersion=3.5.0-SNAPSHOT
 nettyVersion=4.1.105.Final
 floodgateVersion=2.2.0-SNAPSHOT
 fastutilVersion=8.5.11


### PR DESCRIPTION
LimboAPI 1.1.27 adds MINECRAFT_26_2 to WorldVersion and BlockEntityVersion, which is what 26.2 clients need for correct item/block ids. LimboAuth itself holds no protocol-specific code - the public API it uses (Limbo, LimboFactory, VirtualWorld, LimboPlayer, ...) is unchanged between 1.1.26 and 1.1.27 apart from copyright headers - so this is a dependency bump, not a port.

  limboapiVersion  1.1.26          -> 1.1.27
  velocityVersion  3.4.0-SNAPSHOT  -> 3.5.0-SNAPSHOT   (what LimboAPI targets)
  Java             17              -> 21               (LimboAPI is Java 21)